### PR TITLE
Fix parsing the rest text

### DIFF
--- a/src/tag.rs
+++ b/src/tag.rs
@@ -164,6 +164,7 @@ impl<'a> Iterator for HTMLTagIterator<'a> {
                 attributes: "".to_string(),
                 state: HTMLTagState::Text,
             };
+            self.last_index = self.current_index - 1;
             return Some((position, tag));
         }
 

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -3,6 +3,22 @@ use htmlstream::*;
 use htmlstream::HTMLTagState::*;
 
 #[test]
+fn test_parse_rest_text() {
+    let html = "this is a test: <a href=\"http://rust-lang.org\" disabled>The Rust Programing Language</a>\r\n\r\n";
+    let mut list: Vec<(Position, HTMLTag)> = vec![];
+    for (pos, tag) in tag_iter(&html) {
+        list.push((pos, tag));
+    }
+    assert_eq!(list, [
+        (Position { start: 0, end: 16 }, HTMLTag { name: "".to_string(), html: "this is a test: ".to_string(), attributes: "".to_string(), state: Text }),
+        (Position { start: 16, end: 56 }, HTMLTag { name: "a".to_string(), html: "<a href=\"http://rust-lang.org\" disabled>".to_string(), attributes: "href=\"http://rust-lang.org\" disabled".to_string(), state: Opening }),
+        (Position { start: 56, end: 84 }, HTMLTag { name: "".to_string(), html: "The Rust Programing Language".to_string(), attributes: "".to_string(), state: Text }),
+        (Position { start: 84, end: 88 }, HTMLTag { name: "a".to_string(), html: "</a>".to_string(), attributes: "".to_string(), state: Closing }),
+        (Position { start: 88, end: 92 }, HTMLTag { name: "".to_string(), html: "\r\n\r\n".to_string(), attributes: "".to_string(), state: Text })
+    ]);
+}
+
+#[test]
 fn test_parse_tag() {
     let html = "this is a test: <a href=\"http://rust-lang.org\" disabled>The Rust Programing Language</a>";
     let mut list: Vec<(Position, HTMLTag)> = vec![];


### PR DESCRIPTION
I was using the parser and I have noticed that it was getting stuck in an infinite loop when parsing the rest text. It turns out to be a forgotten update of the `self.last_index`. I also added a test case for it.